### PR TITLE
Fixed error in RegwebApi.php

### DIFF
--- a/src/Regweb/RegwebApi.php
+++ b/src/Regweb/RegwebApi.php
@@ -126,7 +126,7 @@ class RegwebApi {
 		$memberData = $response->body;
 		
 		$member = new MemberResource();
-		$member->id = $response->getValue['id'];
+		$member->id 		= $memberData['id'];
 		$member->firstname 	= $memberData['firstname'];
 		$member->lastname 	= $memberData['lastname'];
 		$member->address1 	= $memberData['address1'];


### PR DESCRIPTION
Fixed bug in RegwebApi, the getMember function threw error as it tried to fetch the member id from the wrong place.